### PR TITLE
Removed agbot config from default anax configuration.

### DIFF
--- a/pkgsrc/seed/dynamic/anax.json.tmpl
+++ b/pkgsrc/seed/dynamic/anax.json.tmpl
@@ -16,20 +16,5 @@
     "ExchangeHeartbeat": 60,
     "AgreementTimeoutS": 600,
     "ReportDeviceStatus": true
-  },
-  "AgreementBot": {
-    "DBPath": "${SNAP_COMMON}/var/horizon/",
-    "GethURL": "http://127.0.0.1:8545",
-    "TxLostDelayTolerationSeconds": 240,
-    "AgreementWorkers": 5,
-    "ProtocolTimeoutS": 60,
-    "AgreementTimeoutS": 600,
-    "PolicyPath": "${SNAP_COMMON}/etc/horizon/agbot/policy.d/",
-    "NewContractIntervalS": 15,
-    "ProcessGovernanceIntervalS": 10,
-    "IgnoreContractWithAttribs": "ethereum_account",
-    "ExchangeURL": "https://exchange.bluehorizon.network/api/v1/",
-    "ExchangeHeartbeat": 60,
-    "ActiveDeviceTimeoutS": 180
   }
 }


### PR DESCRIPTION
The original anax configuration template had agbot configuration which activated agbot on the node by default. By removing it, the node will no longer started up as an agbot by default.