### PR TITLE
Changes to horizon-wiotp package

### DIFF
--- a/pkgsrc/deb/shared/debian/horizon-wiotp.postinst
+++ b/pkgsrc/deb/shared/debian/horizon-wiotp.postinst
@@ -1,3 +1,4 @@
 #!/bin/bash
 ln -s /usr/wiotp-edge/bin/wiotp_create_certificate.sh /usr/bin/wiotp_create_certificate
 ln -s /usr/wiotp-edge/bin/wiotp_agent_setup.sh /usr/bin/wiotp_agent_setup
+ln -s /usr/wiotp-edge/bin/wiotp_gwrlac_grp_add_device.sh /usr/bin/wiotp_gwrlac_grp_add_device

--- a/pkgsrc/deb/shared/debian/horizon-wiotp.postrm
+++ b/pkgsrc/deb/shared/debian/horizon-wiotp.postrm
@@ -1,3 +1,4 @@
 #!/bin/bash
 rm -f /usr/bin/wiotp_create_certificate
 rm -f /usr/bin/wiotp_agent_setup
+rm -f /usr/bin/wiotp_gwrlac_grp_add_device

--- a/pkgsrc/seed/horizon-wiotp/fs/usr/wiotp-edge/bin/wiotp_agent_setup.sh
+++ b/pkgsrc/seed/horizon-wiotp/fs/usr/wiotp-edge/bin/wiotp_agent_setup.sh
@@ -214,6 +214,15 @@ checkrc $?
 configJson=$(jq ".microservices[0].variables.WIOTP_CLIENT_ID = \"g:$WIOTP_INSTALL_ORGID:$WIOTP_INSTALL_DEVICE_TYPE:$WIOTP_INSTALL_DEVICE_ID\" " <<< $configJson)
 checkrc $?
 
+configJson=$(jq ".microservices[0].variables.WIOTP_ORG_ID = \"$WIOTP_INSTALL_ORGID\" " <<< $configJson)
+checkrc $?
+
+configJson=$(jq ".microservices[0].variables.WIOTP_DEVICE_TYPE = \"$WIOTP_INSTALL_DEVICE_TYPE\" " <<< $configJson)
+checkrc $?
+
+configJson=$(jq ".microservices[0].variables.WIOTP_DEVICE_ID = \"$WIOTP_INSTALL_DEVICE_ID\" " <<< $configJson)
+checkrc $?
+
 configJson=$(jq ".microservices[0].variables.WIOTP_DEVICE_AUTH_TOKEN = \"$WIOTP_INSTALL_DEVICE_TOKEN\" " <<< $configJson)
 checkrc $?
 

--- a/pkgsrc/seed/horizon-wiotp/fs/usr/wiotp-edge/bin/wiotp_gwrlac_grp_add_device.sh
+++ b/pkgsrc/seed/horizon-wiotp/fs/usr/wiotp-edge/bin/wiotp_gwrlac_grp_add_device.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# FOR INTERNAL USE ONLY (Test environments only)
+# Script for adding a device into the gateway RLAC group
+#
+orgId=$1
+apiKey=$2
+apiToken=$3
+gatewayType=$4
+gatewayId=$5
+deviceType=$6
+deviceId=$7
+testEnv=$8      #optional
+
+if [[ -z $orgId ]] || [[ -z $apiKey ]] || [[ -z $apiToken ]] || [[ -z $gatewayType ]] || [[ -z $gatewayId ]] || [[ -z $deviceType ]] || [[ -z $deviceId ]]; then
+cat <<EOF    
+
+    Usage: $0 <OrgId> <apiKey> <apiToken> <gatewayType> <gatewayId> <deviceType> <deviceId> <testEnviroment>
+    
+    Arguments:
+     OrgId
+     apiKey 
+     apiToken
+     gatewayType
+     gatewayId
+     deviceType
+     deviceId
+     testEnvironment (optional) - if not provided will default to production: internetofthings.ibmcloud.com
+
+EOF
+    exit 1
+fi
+
+if [[ -z $testEnv ]] ; then
+    domain="internetofthings.ibmcloud.com"
+else
+    domain="$testEnv.internetofthings.ibmcloud.com"    
+fi
+echo "Using domain $orgId.$domain ..." 
+echo ""
+
+
+gwId="$orgId%3A$gatewayType%3A$gatewayId"
+echo ""
+echo "Query gateway role g%3A$gwId"
+curl -k -w "%{http_code}" -u "$apiKey:$apiToken" https://$orgId.$domain/api/v0002/authorization/devices/g%3A$gwId
+echo ""
+
+echo ""
+echo "Query RLAC group"
+curl -k -w "%{http_code}" -u "$apiKey:$apiToken" https://$orgId.$domain/api/v0002/bulk/devices/gw_def_res_grp%3A$gwId
+echo ""
+
+echo ""
+echo "Add a device to the group"
+curl -k -w "%{http_code}" -u "$apiKey:$apiToken" -X PUT -H "Content-Type: application/json" https://$orgId.$domain/api/v0002/bulk/devices/gw_def_res_grp%3A$gwId/add  -d "[{\"typeId\":\"$deviceType\",\"deviceId\": \"$deviceId\"}]"
+echo ""
+
+echo ""
+echo "Query RLAC group again"
+curl -k -w "%{http_code}" -u "$apiKey:$apiToken" https://$orgId.$domain/api/v0002/bulk/devices/gw_def_res_grp%3A$gwId
+echo ""
+echo ""
+echo "Done."

--- a/pkgsrc/seed/horizon-wiotp/fs/usr/wiotp-edge/bin/wiotp_gwrlac_grp_add_device.sh
+++ b/pkgsrc/seed/horizon-wiotp/fs/usr/wiotp-edge/bin/wiotp_gwrlac_grp_add_device.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# FOR INTERNAL USE ONLY (Test environments only)
 # Script for adding a device into the gateway RLAC group
 #
 orgId=$1


### PR DESCRIPTION
- Including `wiotp_gwrlac_grp_add_device` script to main installation package (and not in dev-tools) as it is needed for all wiotp environments.
- Including WIOTP_ORG_ID, WIOTP_DEVICE_TYPE and WIOTP_DEVICE_ID env vars that will be used by `edge-connector` in the future. When `edge-connector` starts using these new vars, then WIOTP_CLIENT_ID will be removed from this script.