### PR TITLE
(overdue) security change requested by Egan / Chris Dotson

### DIFF
--- a/pkgsrc/seed/dynamic/anax.json.tmpl
+++ b/pkgsrc/seed/dynamic/anax.json.tmpl
@@ -1,7 +1,7 @@
 {
   "Edge": {
     "TorrentDir": "${SNAP_COMMON}/var/cache/horizon/torrent/",
-    "APIListen": "0.0.0.0:80",
+    "APIListen": "127.0.0.1:80",
     "DBPath": "${SNAP_COMMON}/var/horizon/",
     "GethURL": "http://127.0.0.1:8545",
     "DockerEndpoint": "unix:///var/run/docker.sock",


### PR DESCRIPTION
Note this is an overdue task (I failed to complete it before the new year). This changes the default API interface binding to listen only on the loopback interface (localhost) instead of binding to all interfaces, including public ones. This is an important default but **note that it may break user expectations** and so should be merged cautiously.