### PR TITLE
Adding routing.json file to horizon-wiotp package. 

### DIFF
--- a/pkgsrc/seed/horizon-wiotp/fs/etc/wiotp-edge/routing.json
+++ b/pkgsrc/seed/horizon-wiotp/fs/etc/wiotp-edge/routing.json
@@ -1,0 +1,7 @@
+[
+  {
+    "rule_id": 1,
+    "matching_filter": "#",
+    "destination": "LOCAL"
+  }
+]


### PR DESCRIPTION
This file contains routing rules for edge-connector.