### PR TITLE
Adding `TrustDockerAuthFromOrg: false` 

### DIFF
--- a/pkgsrc/seed/horizon-wiotp/fs/etc/horizon/anax.json
+++ b/pkgsrc/seed/horizon-wiotp/fs/etc/horizon/anax.json
@@ -18,7 +18,8 @@
     "AgreementTimeoutS": 600,
     "ReportDeviceStatus": true,
     "TrustCertUpdatesFromOrg": false,
-    "ServiceUpgradeCheckIntervalS": 300
+    "ServiceUpgradeCheckIntervalS": 300,
+    "TrustDockerAuthFromOrg": false
   },
   "ArchSynonyms": {
     "x86_64": "amd64",

--- a/pkgsrc/seed/horizon-wiotp/fs/etc/horizon/anax.json
+++ b/pkgsrc/seed/horizon-wiotp/fs/etc/horizon/anax.json
@@ -17,7 +17,7 @@
     "ExchangeVersionCheckIntervalM": 720,
     "AgreementTimeoutS": 600,
     "ReportDeviceStatus": true,
-    "TrustCertUpdatesFromOrg": false,
+    "TrustCertUpdatesFromOrg": true,
     "ServiceUpgradeCheckIntervalS": 300,
     "TrustDockerAuthFromOrg": false
   },


### PR DESCRIPTION
As requested in https://github.ibm.com/Blue-Horizon/wiotp-horizon/issues/81.

Looks like the `"ServiceUpgradeCheckIntervalS": 300` flag has already been added.